### PR TITLE
Fix version file syntax errors and URL property

### DIFF
--- a/KerbalAgingMod/KerbalsGetOld.version
+++ b/KerbalAgingMod/KerbalsGetOld.version
@@ -1,6 +1,6 @@
 {
-  "NAME": KerbalsGetOld
-  "URL": "https://github.com/iLikeGothMommys/KerbalsGetOld/blob/main/KerbalAgingMod/KerbalsGetOld.version",
+  "NAME": "KerbalsGetOld",
+  "URL": "https://raw.githubusercontent.com/iLikeGothMommys/KerbalsGetOld/refs/heads/main/KerbalAgingMod/KerbalsGetOld.version",
   "DOWNLOAD": "https://github.com/iLikeGothMommys/KerbalsGetOld/releases",
   "GITHUB": {
     "USERNAME": "iLikeGothMommys",


### PR DESCRIPTION
Hi @iLikeGothMommys,

The version file has two problems:

- The name string is missing quotes
- The URL points to the rich GitHub Web UI HTML page rather than the raw contents

This PR fixes both.

Noticed while reviewing KSP-CKAN/NetKAN#10378.